### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,9 +28,9 @@ writeBlue	KEYWORD2
 readRed	KEYWORD2
 readGreen	KEYWORD2
 readBlue	KEYWORD2
-readTinkerkitInput     KEYWORD2
-readTinkerkitInputA     KEYWORD2
-readTinkerkitInputB     KEYWORD2
+readTinkerkitInput	KEYWORD2
+readTinkerkitInputA	KEYWORD2
+readTinkerkitInputB	KEYWORD2
 tone	KEYWORD2
 noTone	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords