### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/Beginners/EsploraLightCalibrator/EsploraLightCalibrator.ino
+++ b/examples/Beginners/EsploraLightCalibrator/EsploraLightCalibrator.ino
@@ -20,7 +20,7 @@
 // variables:
 int lightMin = 1023;        // minimum sensor value
 int lightMax = 0;           // maximum sensor value
-boolean calibrated = false;  // whether the sensor's been calibrated yet
+bool calibrated = false;  // whether the sensor's been calibrated yet
 
 void setup() {
   // initialize the serial communication:

--- a/examples/Experts/EsploraKart/EsploraKart.ino
+++ b/examples/Experts/EsploraKart/EsploraKart.ino
@@ -38,7 +38,7 @@
   states are different, it means that the button was either
   pressed or released.
  */
-boolean buttonStates[8];
+bool buttonStates[8];
 
 /*
   This array holds the names of the buttons being read.
@@ -93,8 +93,8 @@ void loop() {
 
   // Iterate through all the buttons:
   for (byte thisButton = 0; thisButton < 8; thisButton++) {
-    boolean lastState = buttonStates[thisButton];
-    boolean newState = Esplora.readButton(buttons[thisButton]);
+    bool lastState = buttonStates[thisButton];
+    bool newState = Esplora.readButton(buttons[thisButton]);
     if (lastState != newState) { // Something changed!
       /*
         The Keyboard library allows you to "press" and "release" the

--- a/examples/Experts/EsploraTable/EsploraTable.ino
+++ b/examples/Experts/EsploraTable/EsploraTable.ino
@@ -33,7 +33,7 @@
 /*
  * this variable tells if the data-logging is currently active.
  */
-boolean active = false;
+bool active = false;
 
 /*
  * this variable holds the time in the future when the sketch
@@ -57,7 +57,7 @@ unsigned long startedAt = 0;
  * the "just-after-activation" stuff is run some time later than
  * the code that says "be active now".
  */
-boolean justActivated = false;
+bool justActivated = false;
 
 
 /*
@@ -66,7 +66,7 @@ boolean justActivated = false;
  * this variable and the current status of the switch, it means
  * that the button was either pressed or released.
  */
-boolean lastStartBtn = HIGH;
+bool lastStartBtn = HIGH;
 
 /*
  * Initialization code. The virtual USB keyboard must be
@@ -200,7 +200,7 @@ void activeDelay(unsigned long amount) {
  * function is running.
  */
 void checkSwitchPress() {
-  boolean startBtn = Esplora.readButton(SWITCH_DOWN);
+  bool startBtn = Esplora.readButton(SWITCH_DOWN);
 
   if (startBtn != lastStartBtn) {
     if (startBtn == HIGH) { // button released


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633